### PR TITLE
feat: display markers at site of missing resource reference

### DIFF
--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/JBangFileUtils.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/JBangFileUtils.java
@@ -28,9 +28,9 @@ public class JBangFileUtils {
 
 	public static final Pattern JAVA_INSTRUCTION = Pattern.compile("//JAVA (\\S*).*");
 
-	private static final Pattern SOURCES_INSTRUCTION = Pattern.compile("//SOURCES (\\S*).*");
+	public static final Pattern SOURCES_INSTRUCTION = Pattern.compile("//SOURCES (\\S*).*");
 
-	private static final Pattern FILES_INSTRUCTION = Pattern.compile("//FILES (\\S*).*");
+	public static final Pattern FILES_INSTRUCTION = Pattern.compile("//FILES (\\S*).*");
 
 	private static final int LINE_LIMIT = 300;
 

--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/ErrorKind.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/ErrorKind.java
@@ -1,0 +1,6 @@
+package dev.jbang.eclipse.core.internal.process;
+
+public enum ErrorKind {
+
+	UnresolvedDependency, JavaError, UnresolvedSource, UnresolvedFile, UnknownError
+}

--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangDependencyError.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangDependencyError.java
@@ -8,7 +8,7 @@ public class JBangDependencyError extends JBangError {
 
 
 	public JBangDependencyError(String dependency) {
-		super("Could not resolve dependency " + dependency);
+		super("Could not resolve dependency " + dependency, ErrorKind.UnresolvedDependency);
 		this.setDependency(dependency);
 	}
 

--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangError.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangError.java
@@ -3,9 +3,16 @@ package dev.jbang.eclipse.core.internal.process;
 public class JBangError {
 
 	private String message;
+	
+	private ErrorKind kind;
 
 	public JBangError(String error) {
+		this(error, ErrorKind.UnknownError);
+	}
+	
+	public JBangError(String error, ErrorKind kind) {
 		message = error;
+		this.kind = kind;
 	}
 
 	public String getMessage() {
@@ -14,6 +21,10 @@ public class JBangError {
 
 	public void setMessage(String message) {
 		this.message = message;
+	}
+
+	public ErrorKind getKind() {
+		return kind;
 	}
 
 }

--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangJavaError.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangJavaError.java
@@ -1,9 +1,0 @@
-package dev.jbang.eclipse.core.internal.process;
-
-public class JBangJavaError extends JBangError {
-
-	public JBangJavaError(String error) {
-		super(error);
-	}
-
-}

--- a/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangMissingResource.java
+++ b/dev.jbang.eclipse.core/src/main/java/dev/jbang/eclipse/core/internal/process/JBangMissingResource.java
@@ -1,0 +1,16 @@
+package dev.jbang.eclipse.core.internal.process;
+
+public class JBangMissingResource extends JBangError {
+
+	private String resource;
+
+	public JBangMissingResource(String message, String resource, ErrorKind kind) {
+		super(message, kind);
+		this.resource = resource;
+	}
+
+	public String getResource() {
+		return resource;
+	}
+
+}

--- a/dev.jbang.eclipse.test/src/main/java/dev/jbang/eclipse/core/internal/JBangBuilderTest.java
+++ b/dev.jbang.eclipse.test/src/main/java/dev/jbang/eclipse/core/internal/JBangBuilderTest.java
@@ -71,6 +71,30 @@ public class JBangBuilderTest extends AbstractJBangTest {
 		waitForJobsToComplete();
 		assertErrorMarker(JBangConstants.MARKER_RESOLUTION_ID, "Invalid JAVA version, should be a number optionally followed by a plus sign", 3, "src/hello.java", project);
 	}
+	
+	@Test
+	public void invalidSource() throws Exception {
+		IProject project = jbp.getProject();
+		IFile script = jbp.getMainSourceFile();
+		String content = ResourceUtil.getContent(script);
+		String sources = "//SOURCES missing.java\n";
+		ResourceUtil.setContent(script, content.replace("//JAVA 11", "//JAVA 11\n"+sources));
+
+		waitForJobsToComplete();
+		assertErrorMarker(JBangConstants.MARKER_RESOLUTION_ID, "Could not find missing.java", 4, "src/hello.java", project);
+	}
+	
+	@Test
+	public void invalidFile() throws Exception {
+		IProject project = jbp.getProject();
+		IFile script = jbp.getMainSourceFile();
+		String content = ResourceUtil.getContent(script);
+		String files = "//FILES foo.java=missing.java\n";
+		ResourceUtil.setContent(script, content.replace("//JAVA 11", "//JAVA 11\n"+files));
+
+		waitForJobsToComplete();
+		assertErrorMarker(JBangConstants.MARKER_RESOLUTION_ID, "Could not find 'missing.java'", 4, "src/hello.java", project);
+	}
 
 	@Test
 	public void setReleaseLevel() throws Exception {


### PR DESCRIPTION
Missing //FILES or //SOURCES references are now underlined:

<img width="936" alt="Screenshot 2023-01-08 at 17 47 42" src="https://user-images.githubusercontent.com/148698/211208679-849ad2b7-6e39-4465-ad7c-70cb89f6838e.png">

Caveat: adding the missing files require triggering "Synchronize JBang", either explicitely, or by changing any of the JBang directives, for the error to be removed.